### PR TITLE
#snappy-modal-content 기본 스타일링 삭제

### DIFF
--- a/src/SnappyModal.scss
+++ b/src/SnappyModal.scss
@@ -21,9 +21,6 @@
 #snappy-modal-content {
   position: relative;
   z-index: 2;
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.08);
   grid-area: center;
   align-self: center;
   justify-self: center;


### PR DESCRIPTION
## description
- #snappy-modal-content 에 기본으로 배경색, border, box-shadow 가 있어서 삭제 요청 드립니다.
- 해당 스타일링은 사용자가 직접 모달컴포넌트를 구현할 때 처리하는게 좋아보입니다.

### screenshot
![image](https://github.com/qurugi0347/react-snappy-modal/assets/49504411/2ed32fa0-91cf-4f21-90a6-0a708dfa79ab)
