### PR TITLE
useSnappyModalState

### DIFF
--- a/src/SnappyModal.tsx
+++ b/src/SnappyModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./SnappyModal.css";
+import { SnappyModalExternalStore } from "./context/SnappyModalExternalStorage";
 
 let currentComponent: ModalProgress | undefined;
 export class SnappyModal {
@@ -55,12 +56,14 @@ export class SnappyModal {
     currentComponent?.resolve(value);
     currentComponent = undefined;
     SnappyModal?.removeModalArea();
+    SnappyModalExternalStore.emitChange();
   }
 
   static throw(thrower?: any) {
     currentComponent?.throw(thrower);
     currentComponent = undefined;
     SnappyModal?.removeModalArea();
+    SnappyModalExternalStore.emitChange();
   }
 
   static show(
@@ -77,6 +80,8 @@ export class SnappyModal {
       document.getElementById("snappy-modal-content") as HTMLElement,
     );
     root.render(<React.Fragment>{component}</React.Fragment>);
+
+    SnappyModalExternalStore.emitChange();
 
     return new Promise((resolve, reject) => {
       currentComponent = {

--- a/src/SnappyModal.tsx
+++ b/src/SnappyModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./SnappyModal.css";
-import { SnappyModalExternalStore } from "./context/SnappyModalExternalStorage";
+import { SnappyModalExternalStore } from "./context/useSnappyModalState";
 
 let currentComponent: ModalProgress | undefined;
 export class SnappyModal {
@@ -81,8 +81,6 @@ export class SnappyModal {
     );
     root.render(<React.Fragment>{component}</React.Fragment>);
 
-    SnappyModalExternalStore.emitChange();
-
     return new Promise((resolve, reject) => {
       currentComponent = {
         component,
@@ -95,6 +93,7 @@ export class SnappyModal {
           reject(thrower);
         },
       };
+      SnappyModalExternalStore.emitChange();
     });
   }
 }

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,1 +1,1 @@
-export { useSnappyModalState } from "./SnappyModalExternalStorage";
+export { useSnappyModalState } from "./useSnappyModalState";

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export { useSnappyModalState } from "./SnappyModalExternalStorage";

--- a/src/context/useSnappyModalState.tsx
+++ b/src/context/useSnappyModalState.tsx
@@ -2,6 +2,9 @@ import { SnappyModal } from "../SnappyModal";
 import { useSyncExternalStore } from "react";
 
 let snappyModalListeners = [];
+let snappyModalState = {
+  isShow: false,
+};
 
 function emitChange() {
   for (const listener of snappyModalListeners) {
@@ -10,7 +13,12 @@ function emitChange() {
 }
 
 export const SnappyModalExternalStore = {
-  emitChange,
+  emitChange: () => {
+    snappyModalState = {
+      isShow: SnappyModal.isShow(),
+    };
+    emitChange();
+  },
   subscribe(listener: () => unknown) {
     snappyModalListeners = [...snappyModalListeners, listener];
     return () => {
@@ -18,9 +26,7 @@ export const SnappyModalExternalStore = {
     };
   },
   getSnappyModalState() {
-    return {
-      isShow: SnappyModal.isShow(),
-    };
+    return snappyModalState;
   },
 };
 

--- a/src/context/useSnappyModalState.tsx
+++ b/src/context/useSnappyModalState.tsx
@@ -1,0 +1,32 @@
+import { SnappyModal } from "../SnappyModal";
+import { useSyncExternalStore } from "react";
+
+let snappyModalListeners = [];
+
+function emitChange() {
+  for (const listener of snappyModalListeners) {
+    listener();
+  }
+}
+
+export const SnappyModalExternalStore = {
+  emitChange,
+  subscribe(listener: () => unknown) {
+    snappyModalListeners = [...snappyModalListeners, listener];
+    return () => {
+      snappyModalListeners = snappyModalListeners.filter(l => l !== listener);
+    };
+  },
+  getSnappyModalState() {
+    return {
+      isShow: SnappyModal.isShow(),
+    };
+  },
+};
+
+export const useSnappyModalState = () => {
+  return useSyncExternalStore(
+    SnappyModalExternalStore.subscribe,
+    SnappyModalExternalStore.getSnappyModalState,
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { SnappyModal } from "./SnappyModal";
+export * from "./context";
 
 export default SnappyModal;


### PR DESCRIPTION
# Description

hook을 통해서 SnappyModal의 상태를 관리할 수 있도록 하는 `externalStore` 활용한 hook 추가
