### PR TITLE
FEAT: useCurrentModal 훅 및 modalId 기반 제어 기능 추가

### DIFF
--- a/src/SnappyModal.tsx
+++ b/src/SnappyModal.tsx
@@ -51,13 +51,18 @@ export class SnappyModal {
     return currentComponents.find(c => c.options.layer === Number(layerOrId));
   }
 
-  static removeModalProcess(layerOrId: number | string) {
+  static removeModalProcess(
+    layerOrId: number | string,
+    skipEmitChange = false,
+  ) {
     const index = isModalId(layerOrId)
       ? currentComponents.findIndex(c => c.modalId === layerOrId)
       : currentComponents.findIndex(c => c.options.layer === Number(layerOrId));
     if (index === -1) return;
     currentComponents.splice(index, 1);
-    SnappyModalExternalStore.emitChange();
+    if (!skipEmitChange) {
+      SnappyModalExternalStore.emitChange();
+    }
   }
 
   static getModalProcess() {
@@ -66,14 +71,18 @@ export class SnappyModal {
 
   static close(value?: any, layerOrId: number | string = 0) {
     const currentComponent = this.getCurrentComponent(layerOrId);
-    currentComponent?.resolve(value);
-    this.removeModalProcess(layerOrId);
+    if (!currentComponent) return;
+
+    this.removeModalProcess(layerOrId, true);
+    currentComponent.resolve(value);
   }
 
   static throw(thrower?: any, layerOrId: number | string = 0) {
     const currentComponent = this.getCurrentComponent(layerOrId);
-    currentComponent?.throw(thrower);
-    this.removeModalProcess(layerOrId);
+    if (!currentComponent) return;
+
+    this.removeModalProcess(layerOrId, true);
+    currentComponent.throw(thrower);
   }
 
   static show(

--- a/src/SnappyModal.tsx
+++ b/src/SnappyModal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./SnappyModal.css";
 import { SnappyModalExternalStore } from "./context/useSnappyModalState";
+import { CurrentModalProvider } from "./context/CurrentModalContext";
 
 const currentComponents: ModalProgress[] = [];
 export class SnappyModal {
@@ -48,7 +49,15 @@ export class SnappyModal {
 
     return new Promise((resolve, reject) => {
       currentComponents.push({
-        component: () => <React.Fragment>{component}</React.Fragment>,
+        component: ({ resolveFunc, rejectFunc, layer }) => (
+          <CurrentModalProvider
+            resolve={resolveFunc}
+            reject={rejectFunc}
+            layer={layer}
+          >
+            {component}
+          </CurrentModalProvider>
+        ),
         options: dialogOptions,
         resolve: (value: any) => {
           resolve(value);

--- a/src/SnappyModal.tsx
+++ b/src/SnappyModal.tsx
@@ -4,6 +4,35 @@ import "./SnappyModal.css";
 import { SnappyModalExternalStore } from "./context/useSnappyModalState";
 import { CurrentModalProvider } from "./context/CurrentModalContext";
 
+function generateModalId(): string {
+  // Modern browsers with crypto.randomUUID()
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  // Fallback for older browsers using crypto.getRandomValues()
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+
+    // Set version (4) and variant bits
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    const hex = Array.from(bytes, byte =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  // Final fallback for very old environments
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 function isModalId(layerOrId: number | string): boolean {
   const asNumber = Number(layerOrId);
   return isNaN(asNumber);
@@ -56,7 +85,7 @@ export class SnappyModal {
       ...options,
     };
 
-    const modalId = crypto.randomUUID();
+    const modalId = generateModalId();
 
     return new Promise((resolve, reject) => {
       currentComponents.push({

--- a/src/context/CurrentModalContext.tsx
+++ b/src/context/CurrentModalContext.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext } from "react";
+import { SnappyModal } from "../SnappyModal";
+
+interface CurrentModalContextType {
+  resolve: (value?: any) => void;
+  reject: (error?: any) => void;
+  layer: number;
+}
+
+const CurrentModalContext = createContext<CurrentModalContextType | null>(null);
+
+export const CurrentModalProvider = ({
+  children,
+  resolve,
+  reject,
+  layer,
+}: {
+  children: React.ReactNode;
+  resolve: (value?: any) => void;
+  reject: (error?: any) => void;
+  layer: number;
+}) => {
+  return (
+    <CurrentModalContext.Provider value={{ resolve, reject, layer }}>
+      {children}
+    </CurrentModalContext.Provider>
+  );
+};
+
+export const useCurrentModal = () => {
+  const context = useContext(CurrentModalContext);
+  if (!context) {
+    throw new Error("useCurrentModal must be used within CurrentModalProvider");
+  }
+  return {
+    resolveModal: (value?: any) => {
+      context.resolve(value);
+      SnappyModal.removeModalProcess(context.layer);
+    },
+    rejectModal: (error?: any) => {
+      context.reject(error);
+      SnappyModal.removeModalProcess(context.layer);
+    },
+    layer: context.layer,
+  };
+};

--- a/src/context/CurrentModalContext.tsx
+++ b/src/context/CurrentModalContext.tsx
@@ -5,6 +5,7 @@ interface CurrentModalContextType {
   resolve: (value?: any) => void;
   reject: (error?: any) => void;
   layer: number;
+  modalId: string;
 }
 
 const CurrentModalContext = createContext<CurrentModalContextType | null>(null);
@@ -14,14 +15,16 @@ export const CurrentModalProvider = ({
   resolve,
   reject,
   layer,
+  modalId,
 }: {
   children: React.ReactNode;
   resolve: (value?: any) => void;
   reject: (error?: any) => void;
   layer: number;
+  modalId: string;
 }) => {
   return (
-    <CurrentModalContext.Provider value={{ resolve, reject, layer }}>
+    <CurrentModalContext.Provider value={{ resolve, reject, layer, modalId }}>
       {children}
     </CurrentModalContext.Provider>
   );
@@ -35,12 +38,13 @@ export const useCurrentModal = () => {
   return {
     resolveModal: (value?: any) => {
       context.resolve(value);
-      SnappyModal.removeModalProcess(context.layer);
+      SnappyModal.removeModalProcess(context.modalId);
     },
     rejectModal: (error?: any) => {
       context.reject(error);
-      SnappyModal.removeModalProcess(context.layer);
+      SnappyModal.removeModalProcess(context.modalId);
     },
     layer: context.layer,
+    modalId: context.modalId,
   };
 };

--- a/src/context/SnappyModalContext.tsx
+++ b/src/context/SnappyModalContext.tsx
@@ -31,7 +31,10 @@ export const SnappyModalProvider = ({ children }) => {
   const modalRendered = useMemo(() => {
     const { modalProgress } = snappyModal;
     return modalProgress.map(modal => (
-      <div key={modal.modalId} {...assignModalOptions(modal.options)}>
+      <div
+        key={modal.modalId}
+        {...assignModalOptions(modal.options, modal.modalId)}
+      >
         <div
           className={`snappy-modal-content ${modal.options.className ? `${modal.options.className}` : ""}`}
           style={modal.options.style}
@@ -56,7 +59,10 @@ export const SnappyModalProvider = ({ children }) => {
   );
 };
 
-export function assignModalOptions(options: SnappyModalOptions) {
+export function assignModalOptions(
+  options: SnappyModalOptions,
+  modalId: string,
+) {
   const domOptions = {
     classList: ["snappy-modal-area"],
     styleProperty: {},
@@ -82,7 +88,7 @@ export function assignModalOptions(options: SnappyModalOptions) {
     domOptions.onClick = e => {
       e.stopPropagation();
       e.preventDefault();
-      SnappyModal.close(undefined, options.layer);
+      SnappyModal.close(undefined, modalId);
     };
   }
   if (options.zIndex !== undefined) {

--- a/src/context/SnappyModalContext.tsx
+++ b/src/context/SnappyModalContext.tsx
@@ -31,7 +31,7 @@ export const SnappyModalProvider = ({ children }) => {
   const modalRendered = useMemo(() => {
     const { modalProgress } = snappyModal;
     return modalProgress.map(modal => (
-      <div key={modal.options.layer} {...assignModalOptions(modal.options)}>
+      <div key={modal.modalId} {...assignModalOptions(modal.options)}>
         <div
           className={`snappy-modal-content ${modal.options.className ? `${modal.options.className}` : ""}`}
           style={modal.options.style}
@@ -41,6 +41,7 @@ export const SnappyModalProvider = ({ children }) => {
             resolveFunc={modal.resolve}
             rejectFunc={modal.throw}
             layer={modal.options.layer}
+            modalId={modal.modalId}
           />
         </div>
       </div>

--- a/src/context/SnappyModalContext.tsx
+++ b/src/context/SnappyModalContext.tsx
@@ -37,7 +37,11 @@ export const SnappyModalProvider = ({ children }) => {
           style={modal.options.style}
           onClick={e => e.stopPropagation()}
         >
-          <modal.component />
+          <modal.component
+            resolveFunc={modal.resolve}
+            rejectFunc={modal.throw}
+            layer={modal.options.layer}
+          />
         </div>
       </div>
     ));

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,2 +1,3 @@
 export { useSnappyModalState } from "./useSnappyModalState";
 export { SnappyModalProvider } from "./SnappyModalContext";
+export { useCurrentModal } from "./CurrentModalContext";


### PR DESCRIPTION
## Summary
모달 내부에서 현재 모달을 제어할 수 있는 `useCurrentModal` 훅을 추가하고, 각 모달에 고유 UUID를 부여하여 modalId 기반 제어를 지원합니다.

## Changes

### 1. useCurrentModal 훅 추가
**파일:** `src/context/CurrentModalContext.tsx` (신규), `src/context/index.ts`

**변경 내용:**
- 모달 내부에서 현재 모달을 제어할 수 있는 Context 및 Hook 구현
- `resolveModal()`: 모달을 resolve하고 닫기
- `rejectModal()`: 모달을 reject하고 닫기
- `layer`: 현재 모달의 layer 정보
- `modalId`: 현재 모달의 고유 ID

**사용 예시:**
```typescript
import { useCurrentModal } from 'react-snappy-modal';

function MyModalContent() {
  const { resolveModal, rejectModal, modalId } = useCurrentModal();
  
  const handleConfirm = () => {
    resolveModal({ confirmed: true });
  };
  
  const handleCancel = () => {
    rejectModal(new Error('User cancelled'));
  };
  
  return (
    <div>
      <h2>Modal {modalId}</h2>
      <button onClick={handleConfirm}>확인</button>
      <button onClick={handleCancel}>취소</button>
    </div>
  );
}
```

### 2. modalId 기반 모달 제어
**파일:** `src/SnappyModal.tsx`, `src/context/SnappyModalContext.tsx`

**변경 내용:**
- 각 모달에 고유 UUID 자동 생성
- `SnappyModal.close()`, `SnappyModal.throw()`, `SnappyModal.getCurrentComponent()` 메서드가 layer 또는 modalId로 모달 식별 가능
- React key로 layer 대신 modalId 사용하여 안정성 향상

**코드 예시:**
```typescript
// Before - layer로만 제어 가능
SnappyModal.close(value, 0); // layer 0번 모달 닫기

// After - layer 또는 modalId로 제어 가능
SnappyModal.close(value, 0); // layer 0번 모달 닫기
SnappyModal.close(value, 'uuid-string'); // 특정 modalId 모달 닫기
```

### 3. CurrentModalProvider 통합
**파일:** `src/SnappyModal.tsx`, `src/context/SnappyModalContext.tsx`

**변경 내용:**
- 모든 모달 컴포넌트가 자동으로 CurrentModalProvider로 래핑
- 모달 컴포넌트 내에서 useCurrentModal 훅 사용 가능
- resolve, reject 함수와 layer, modalId 정보 자동 주입

## 기술 스택
- React Context API
- TypeScript
- crypto.randomUUID() for unique modal IDs

## Test plan
- [ ] useCurrentModal 훅에서 resolveModal 호출 시 모달이 정상적으로 닫히는지 확인
- [ ] useCurrentModal 훅에서 rejectModal 호출 시 모달이 정상적으로 닫히고 에러가 전달되는지 확인
- [ ] modalId로 특정 모달을 제어할 수 있는지 확인
- [ ] 여러 모달이 동시에 열렸을 때 각 모달의 modalId가 고유한지 확인
- [ ] 기존 layer 기반 제어 방식이 여전히 동작하는지 확인 (하위 호환성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 모달을 고유 ID(modalId) 또는 레이어 번호로 식별할 수 있게 개선되었습니다.
  * 컨텍스트 기반 CurrentModalProvider와 useCurrentModal 훅이 추가되어 모달 내부에서 resolve/reject, layer, modalId에 접근·호출할 수 있습니다.
  * 모달 진행 상태에 modalId가 포함되어 모달 추적이 쉬워졌습니다.

* **Breaking Change**
  * 모달 컴포넌트에 resolve/reject, layer, modalId가 전달되는 사용 방식으로 확장되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->