### PR TITLE
FIX: allowScroll 옵션이 false일 때만 스크롤 잠금 동작하도록 수정

### DIFF
--- a/src/context/SnappyModalContext.tsx
+++ b/src/context/SnappyModalContext.tsx
@@ -7,8 +7,15 @@ const SnappyModalContext = createContext({});
 export const SnappyModalProvider = ({ children }) => {
   const snappyModal = useSnappyModalState();
 
+  const shouldBlockScroll = useMemo(() => {
+    if (!snappyModal.isShow) return false;
+    return snappyModal.modalProgress.some(
+      modal => modal.options.allowScroll === false,
+    );
+  }, [snappyModal.isShow, snappyModal.modalProgress]);
+
   useEffect(() => {
-    if (!snappyModal.isShow) return;
+    if (!shouldBlockScroll) return;
 
     const htmlElement = document.getElementsByTagName("html")[0];
     const pageX = window.scrollX;
@@ -26,7 +33,7 @@ export const SnappyModalProvider = ({ children }) => {
         top: pageY,
       });
     };
-  }, [snappyModal.isShow]);
+  }, [shouldBlockScroll]);
 
   const modalRendered = useMemo(() => {
     const { modalProgress } = snappyModal;


### PR DESCRIPTION
## Summary
- 기존에는 모달이 표시되면 무조건 배경 스크롤이 잠겼음
- 이제 `allowScroll: false`인 모달이 하나라도 있을 때만 스크롤을 잠금
- `allowScroll: true`로 설정된 모달만 있을 경우 배경 스크롤 허용

## Changes
- `shouldBlockScroll` 변수 추가하여 스크롤 잠금 조건 분리
- `modalProgress` 배열에서 `allowScroll === false`인 모달이 있는지 확인

## Test plan
- [ ] `allowScroll: false` (기본값)로 모달 열기 → 배경 스크롤 잠김 확인
- [ ] `allowScroll: true`로 모달 열기 → 배경 스크롤 가능 확인
- [ ] 다중 모달에서 하나라도 `allowScroll: false`면 스크롤 잠김 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 모달의 스크롤 잠금 기능이 개별 모달의 스크롤 설정에 따라 더 정확하게 작동하도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->